### PR TITLE
CamelCasing adminDn so it is consistent with node-ldapauth's property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ npm install passport-ldapauth
 
 * `server`: LDAP settings. These are passed directly to [node-ldapauth](https://github.com/trentm/node-ldapauth)
     * `url`: e.g. `ldap://localhost:389`
-    * `adminDN`: e.g. `cn='root'`
-    * `adminPassword`: Password for adminDN
+    * `adminDn`: e.g. `cn='root'`
+    * `adminPassword`: Password for adminDn
     * `searchBase`: e.g. `o=users,o=example.com`
     * `searchFilter`:  LDAP search filter, e.g. `(uid={{username}})`. Use literal `{{username}}` to have the given username used in the search.
 * `usernameField`: Field name where the username is found, defaults to _username_

--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -30,7 +30,7 @@ var passport = require('passport'),
  *     passport.use(new LdapStrategy({
  *         server: {
  *           url: 'ldap://localhost:389',
- *           adminDN: 'cn=root',
+ *           adminDn: 'cn=root',
  *           adminPassword: 'secret',
  *           searchBase: 'ou=passport-ldapauth',
  *           searchFilter: '(uid={{username}})'


### PR DESCRIPTION
Stumbled upon this by accident, but using `adminDN` (rather than `adminDn`) leads to assertion errors in node-ldapauth. It's written correctly in the example put it has the uppercase DN in the documentation which could be a bit misleading.
