### PR TITLE
Multiple LDAP Server Configurations Support

### DIFF
--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -174,13 +174,18 @@ Strategy.prototype.authenticate = function(req, options) {
   if ((typeof this.options === 'object') && (!this.getOptions)) {
     return handleAuthentication.call(this, req, options);
   }
-
-  this.getOptions(function(err, configuration) {
+  var callback = function(err, configuration) {
     if (err) return this.fail(err);
 
     this.options = setDefaults(configuration);
     handleAuthentication.call(this, req, options);
-  }.bind(this));
+  };
+  // Added functionality: getOptions can accept now up to 2 parameters
+  if (this.getOptions.length ===1) { // Accepts 1 parameter, backwards compatibility
+    this.getOptions(callback.bind(this));
+  } else { // Accepts 2 parameters, pass request as well
+    this.getOptions(req, callback.bind(this));
+  }
 };
 
 module.exports = Strategy;


### PR DESCRIPTION
Hello,

I need the functionality discussed on https://github.com/vesse/passport-ldapauth/pull/13 . You finally didn't accept the change because was not backwards compatible. Wise desicion.

I've taken the liberty to redo this work, with the changes you were demanding:
  - The callback which returns the LDAP options is checked and called with 1 or 2 arguments to ensure backwards compatibility.
  - Existing tests pass and new tests are added to check the 2-argument trick.

Thank you very much for your work,
Ferran
