### PR TITLE
Support for creds in headers and authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+.idea
+npm-debug.log

--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -23,6 +23,7 @@ var passport = require('passport-strategy'),
  * - `usernameField`  field name where the username is found, defaults to _username_
  * - `passwordField`  field name where the password is found, defaults to _password_
  * - `passReqToCallback`  when `true`, `req` is the first argument to the verify callback (default: `false`)
+ * - `passAuthOptionsToCallback`  when `true`, `options` from the passport.authenticate call will be the first argument to the verify callback (default: `false`)
  *
  * Options can be also given as function that accepts a callback end calls it
  * with error and options arguments. Notice that the callback is executed on
@@ -134,6 +135,13 @@ var handleAuthentication = function(req, options) {
   password = lookup(req.body, this.options.passwordField) || lookup(req.query, this.options.passwordField);
 
   if (!username || !password) {
+    var auth = require('basic-auth');
+    var credentials = auth(req)
+    username = credentials.name;
+    password = credentials.pass;
+  }
+
+  if (!username || !password) {
     return this.fail({message: options.badRequestMessage || 'Missing credentials'}, 400);
   }
 
@@ -156,8 +164,12 @@ var handleAuthentication = function(req, options) {
 
     // Execute given verify function
     if (this.verify) {
-      if (this.options.passReqToCallback) {
+      if (this.options.passReqToCallback && this.options.passAuthOptionsToCallback) {
+        return this.fail({message: options.passToCallback || 'Options passReqToCallback and passAuthOptionsToCallback cannot both be true'}, 401);
+      } else if (this.options.passReqToCallback) {
         return this.verify(req, user, verify.call(this));
+      } else if (this.options.passAuthOptionsToCallback) {
+        return this.verify(options, user, verify.call(this));
       } else {
         return this.verify(user, verify.call(this));
       }

--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -136,9 +136,11 @@ var handleAuthentication = function(req, options) {
 
   if (!username || !password) {
     var auth = require('basic-auth');
-    var credentials = auth(req)
-    username = credentials.name;
-    password = credentials.pass;
+    var credentials = auth(req);
+    if (credentials) {
+      username = credentials.name;
+      password = credentials.pass;
+    }
   }
 
   if (!username || !password) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "authentication",
     "ldapauth"
   ],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": {
     "type": "MIT",
     "url": "https://github.com/vesse/passport-ldapauth/raw/master/LICENSE"
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "passport-strategy": "1.x.x",
-    "ldapauth-fork": "~2.3.0"
+    "ldapauth-fork": "~2.3.0",
+    "basic-auth": "1.0.1"
   },
   "devDependencies": {
     "body-parser": "1.12.x",


### PR DESCRIPTION
- added support for user/pass in headers
- added support for to pass authentication options back to verify function; this will allow for authorization.

for instance
- app.post("/someAdminSerice", passport.authenticate('ldapauth', { authorizatioRole:"admin" }), function(req, res) {....});
- app.post("/somePublicSerice", passport.authenticate('ldapauth', { authorizatioRole:"public" }), function(req, res) {....});

And in the verify function, you can check to see if those roles are associated with that user.