### PR TITLE
ability to handle errors as failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea/

--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -173,8 +173,20 @@ var handleAuthentication = function(req, options) {
       if (err.name === 'ConstraintViolationError'){
         return this.fail({message: options.constraintViolation || 'Exceeded password retry limit, account locked'}, 401);
       }
+
       // Other errors are (most likely) real errors
-      return this.error(err);
+      if (options.handleErrorsAsFailures) {
+        // If we've been told to handle errors as failures...
+        if (options.failureErrorCallback && typeof options.failureErrorCallback === 'function') {
+          // If a failure-error callback has been provided, pass the error to that first.
+          options.failureErrorCallback(err);
+        }
+
+        return this.fail(err, 500);
+      } else {
+        // ...otherwise, an error is an error.
+        return this.error(err);
+      }
     }
 
     if (!user) return this.fail({message: options.userNotFound || 'Invalid username/password'}, 401);


### PR DESCRIPTION
#### Update

See vesse/node-ldapauth-fork#25 and the new comment, below.

---
## Background

In our application, we provide the ability for an admin to configure LDAP authentication via a UI. The configuration is persisted to a database. The admin can also enable and disable this authentication on the fly. This results in the registration (`passport.use(...)`) or de-registration (`passport.unuse(...)`) of an instance of this Passport strategy, respectively.

While implementing this functionality, we noticed that mistyped configuration (mainly a mistyped LDAP hostname) or network connectivity issues resulted in an unhandled exception, rather than an error passed to the `authenticate` callback. After investigating, we found some error-trapping issues in **node-ldapauth-fork** for which we have submitted a pull request (vesse/node-ldapauth-fork#26). After changing that code, we no longer had unhandled exceptions, but errors of this kind failed the entire authentication process instead of passing on to the next strategy.
## Motivation

It seems likely that, at times, this would be the desired behavior. In our case, however, we'd like the ability to allow any errors in the LDAP authentication process to simply fail that strategy and allow Passport to move on to the next strategy. (In our configuration, "local" is the last strategy which we would fall back to to ensure that it is always possible to log in.) In that spirit, I've made some minor changes to this strategy. Please note that I have not made changes to the README or added unit tests as I'd like to have a conversation with you first about how you feel is best to implement this.

I've added two additional options recognized by the `authenticate` code:
- `handleErrorsAsFailures` - Instead of calling `this.error(err)`, `this.fail(err, 500)` will be called and control will be passed to the next strategy in line.
- `failureErrorCallback` - Before an error is passed to `fail`, it is passed to the function provided in this option. If all strategies do _not_ fail, then the errors will be swallowed. This allows the error to be logged, even if the strategy will ultimately pass on.
## Variations

That said, there are several ways that this could be implemented. I wanted to discuss some of those variations with you.
### Options At Registration Vs. Authentication
- **Provided At Registration**  
  It may make more sense to provide them here, as a configuration choice like the one represented by these options may be more of an "overall" choice than one that might change at each of various calls to `passport.authenticate(...)`.
- **Provided At Authentication**  
  On the other hand, it might make more sense to allow more flexibility. In our application, one of our future tasks is to always run a test authenticate call whenever the strategy configuration is saved to alleviate some of these issues altogether. In that case, if the strategy were configured with the options at _registration_, we'd need to set one up without those options, run that, remove it and then ultimately set it up again in its final configuration. If it were configured at _authentication_, this task would be somewhat cleaner.
- **Provided At Both??**  
  The third option is more complex, but could allow a "default" configuration at registration that might be overridden by options passed in at authentication. I'm not sure that complexity is warranted, though.
### `failureErrorCallback` Return Value

The `failureErrorCallback` function could be expected to return a truthy or falsy (or explicitly `true` or `false`) value to indicate whether the error should continue to be handled as a failure or if it should actually go back to being handled as an error. This would give the consuming code the ability to "configure" the behavior of the strategy mid-flight, somewhat.

That said, I wonder if something like that is almost not antithetical to the spirit of Passport. It's not something I've ever seen in another strategy, before. Perhaps you have more of a feeling for this.
## Conclusion

I'm sorry for the book for such a simple bit of code, but I wanted to make sure I respected your intentions with this strategy and presented an idea to you wrapped in a conversation rather than simply dropping code on your lap with a note that says it makes what you wrote better. What are your thoughts on how this should go together? Is a feature like this, in fact, out of scope for this strategy?

I eagerly await your response.
