### PR TITLE
Fix typo in Leonidasoy link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ If the query does not return expected user the configuration is likely incorrect
 
 MIT
 
-`passport-ldapauth` has been partially sponsored by [Leonidas Ltd](https://leonidasoy.fi/opensource).
+`passport-ldapauth` has been partially sponsored by [Leonidas Ltd](https://leonidasoy.fi/open-source).


### PR DESCRIPTION
The old link was leading to a 404 error on their website. This seems to be the correct one.