### PR TITLE
Defined an error message specifically for NoSuchObjectError.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Use `passport.authenticate()`, specifying the `'ldapauth'` strategy, to authenti
 In addition to [default authentication options](http://passportjs.org/guide/authenticate/) the following flash message options are available for `passport.authenticate()`:
 
  * `badRequestMessage`: missing username/password (default: 'Missing credentials')
- * `invalidCredentials`: `InvalidCredentialsError`, `NoSuchObjectError`, and `/no such user/i` LDAP errors (default: 'Invalid username/password')
+ * `invalidCredentials`: `InvalidCredentialsError` and `/no such user/i` LDAP errors (default: 'Invalid username/password')
+ * `noSuchObject`: `NoSuchObjectError` LDAP errors (default: 'Bad search base')
  * `userNotFound`: LDAP returns no error but also no user (default: 'Invalid username/password')
  * `constraintViolation`: user account is locked (default: 'Exceeded password retry limit, account locked')
 

--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -279,7 +279,13 @@ var handleAuthentication = function(req, options) {
     if (err) {
       // Invalid credentials / user not found are not errors but login failures
       if (err.name === 'InvalidCredentialsError' || err.name === 'NoSuchObjectError' || (typeof err === 'string' && err.match(/no such user/i))) {
-        var message = options.invalidCredentials || 'Invalid username/password';
+        var message;
+        if (err.name === 'NoSuchObjectError') {
+          message = options.noSuchObject || 'Bad search base';
+        }
+        else {
+          message = options.invalidCredentials || 'Invalid username/password';
+        }
 
         if (err.message) {
           var ldapComment = err.message.match(/data ([0-9a-fA-F]*), v[0-9a-fA-F]*/);


### PR DESCRIPTION
Added a distinct error message for the NoSuchObjectError to make it easier to diagnose authentication errors that are not invalid credentials.