### PR TITLE
Only catch the 'error' event once.

### DIFF
--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -270,7 +270,8 @@ var handleAuthentication = function(req, options) {
   };
 
   ldap = new LdapAuth(this.options.server);
-  ldap.on('error', errorHandler);
+  ldap.once('error', errorHandler);
+  ldap.on('error', function() { /* Ignored */ });
   ldap.authenticate(username, password, function(err, user) {
     ldap.close(function(){
       // We don't care about the closing


### PR DESCRIPTION
Works around https://github.com/vesse/node-ldapauth-fork/issues/53