### PR TITLE
Support options.missingCredentialsStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ passport.use(new LdapStrategy({
 * `usernameField`: Field name where the username is found, defaults to _username_
 * `passwordField`: Field name where the password is found, defaults to _password_
 * `credentialsLookup`: Optional, synchronous function that provides the login credentials from `req`. See [below](#credentialslookup) for more.
+* `missingCredentialsStatus`: Returned HTTP status code when credentials could not be found in the request. Defaults to _400_
 * `handleErrorsAsFailures`: When `true`, unknown errors and ldapjs emitted errors are handled as authentication failures instead of errors (default: `false`).
 * `failureErrorCallback`: Optional, synchronous function that is called with the received error when `handleErrorsAsFailures` is enabled.
 * `passReqToCallback`: When `true`, `req` is the first argument to the verify callback (default: `false`):

--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -128,6 +128,7 @@ var setDefaults = function(options) {
  * @param {Object} options.server - [ldapauth-fork options]{@link https://github.com/vesse/node-ldapauth-fork}
  * @param {string} [options.usernameField=username] - Form field name for username
  * @param {string} [options.passwordField=password] - Form field name for password
+ * @param {Number} [options.missingCredentialsStatus=400] - HTTP status code returned when credentials are missing from the request
  * @param {boolean} [options.passReqToCallback=false] - If true, request is passed to verify callback
  * @param {credentialsLookup} [options.credentialsLookup] - Credentials lookup function to use instead of default
  * @param {boolean} [options.handleErrorAsFailures=false] - Set to true to handle errors as login failures
@@ -248,7 +249,7 @@ var handleAuthentication = function(req, options) {
   }
 
   if (!username || !password) {
-    return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
+    return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, this.options.missingCredentialsStatus || 400);
   }
 
   errorHandler = this.options.handleErrorsAsFailures === true ? handleErrorAsFailure.bind(this) : this.error.bind(this);

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -224,6 +224,18 @@ describe('LDAP authentication strategy', function() {
           .end(cb);
       });
     });
+
+    it('should support returning a custom status code when credentials are missing', function(cb) {
+      var OPTS = JSON.parse(JSON.stringify(BASE_OPTS));
+      OPTS.missingCredentialsStatus = 401;
+
+      start_servers(OPTS, BASE_TEST_OPTS)(function() {
+        request(expressapp)
+          .post('/login')
+          .expect(401)
+          .end(cb);
+      });
+    });
   });
 
   describe('with options as function', function() {


### PR DESCRIPTION
I know this was discussed before in https://github.com/vesse/passport-ldapauth/issues/17, but I think we should allow users to configure the status code returned by the libray when credentials are not given in the request at all.
For instance with basic authentication, endpoints usually return 401.