### PR TITLE
Async options retrieval error is handled through this.error()

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ var ldapOpts = {
 ## Asynchronous configuration retrieval
 
 Instead of providing a static configuration object, you can pass a function as `options` that will take care of fetching the configuration. It will be called with the `req` object and a callback function having the standard `(err, result)` signature. Notice that the provided function will be called on every authenticate request.
+If the function returns an error, the authentication request will error out with that error.
 
 ```javascript
 var getLDAPConfiguration = function(req, callback) {

--- a/lib/passport-ldapauth/strategy.js
+++ b/lib/passport-ldapauth/strategy.js
@@ -346,7 +346,7 @@ Strategy.prototype.authenticate = function(req, options) {
 
   var callback = function(err, configuration) {
     if (err) {
-      return this.fail(err);
+      return this.error(err);
     }
 
     this.options = setDefaults(configuration);

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -324,6 +324,25 @@ describe('LDAP authentication strategy', function() {
     });
   });
 
+  describe('with options as function returning an error', function() {
+    var opts = function(cb) {
+      process.nextTick(function() {
+        cb(new Error('What a terrible failure'));
+      });
+    };
+
+    before(start_servers(opts, BASE_TEST_OPTS));
+    after(stop_servers);
+
+    it('should fail the authentication with an error', function(cb) {
+      request(expressapp)
+        .post('/login')
+        .send({username: 'valid', password: 'valid'})
+        .expect(500)
+        .end(cb);
+    });
+  });
+
   describe('with group fetch settings defined', function() {
     var OPTS;
 


### PR DESCRIPTION
Hi @vesse 

I came accross this while working on LDAP auth for one of our products. Our use case is to query a DNS SRV record in order to obtain the address of the server. I definitely think that if the `getOptions` function errors out, the error should be propagated as such and not _hidden_ as an authentication failure. The authentication did not happen yet.

WDYT ?

This would be a breaking change, though I'm unsure of the impact as most users should already handle errors fine anyway...

Thanks !
David