### PR TITLE
Fix custom CA example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Simple example config for connecting over `ldaps://` to a server requiring some 
 
 ```javascript
 var fs = require('fs');
+var tls = require('tls');
 
 var opts = {
   server: {
@@ -125,9 +126,9 @@ var opts = {
     searchFilter: '(&(objectcategory=person)(objectclass=user)(|(samaccountname={{username}})(mail={{username}})))',
     searchAttributes: ['displayName', 'mail'],
     tlsOptions: {
-      ca: [
-        fs.readFileSync('/path/to/root_ca_cert.crt')
-      ]
+      secureContext: tls.createSecureContext({
+        ca: fs.readFileSync('/path/to/root_ca_cert.crt')
+      })
     }
   }
 };


### PR DESCRIPTION
The example of how to connect to an internal LDAP server using a custom CA certificate to trust (as common in enterprise environments) is not valid for the way NodeJS handles TLS.

I've updated it with the correct way, which is to pass in a custom secureContext.